### PR TITLE
Mattheworiordan node js support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,14 @@ Actioncable is good stuff, even if it is in Ruby.
 * You will need to pass the origin to the WebSocket library as Rails will by default reject requests with an invalid origin.  See example below:
 
 ```javascript
-const consumer = Cable.createConsumer('ws://0.0.0.0:3000/cable', { origin: 'http://0.0.0.0:3000' });
+const consumer = Cable.createConsumer('ws://0.0.0.0:3000/cable', { createWebsocket: () => {
+  var WebSocketLib = require('websocket').w3cwebsocket;
+  this.webSocket = new WebSocket(
+     'ws://0.0.0.0:3000/cable',
+     protocols,
+     'http://0.0.0.0:3000',
+     headers,
+     extraRequestOptions
+   );
+} });
 ```

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ Actioncable is good stuff, even if it is in Ruby.
 
 ```javascript
 const consumer = Cable.createConsumer('ws://0.0.0.0:3000/cable', { createWebsocket: () => {
-  var WebSocketLib = require('websocket').w3cwebsocket;
-  this.webSocket = new WebSocket(
+  var w3cwebsocket = require('websocket').w3cwebsocket;
+  let webSocket = new w3cwebsocket(
      'ws://0.0.0.0:3000/cable',
      protocols,
      'http://0.0.0.0:3000',
      headers,
      extraRequestOptions
    );
+   return webSocket;
 } });
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Actioncable is good stuff, even if it is in Ruby.
 
 `es6-actioncable` will work under Node.js, however you will need to bear the following in mind:
 
+* You will need to supply your own websocket library, 2 out of 2 developers recommend: https://www.npmjs.com/package/websocket.
 * Your ActionCable Rails server must be bound to a specific IP or `0.0.0.0`, but not localhost. This can be done as follows `rails server -b 0.0.0.0`. See https://twitter.com/mattheworiordan/status/713350750483693568 for an explanation of the issue.
 * You will need to pass the origin to the WebSocket library as Rails will by default reject requests with an invalid origin.  See example below:
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,14 @@ MyChannel.js
     }
 
 Actioncable is good stuff, even if it is in Ruby.
+
+## Connecting from Node.js
+
+`es6-actioncable` will work under Node.js, however you will need to bear the following in mind:
+
+* Your ActionCable Rails server must be bound to a specific IP or `0.0.0.0`, but not localhost. This can be done as follows `rails server -b 0.0.0.0`. See https://twitter.com/mattheworiordan/status/713350750483693568 for an explanation of the issue.
+* You will need to pass the origin to the WebSocket library as Rails will by default reject requests with an invalid origin.  See example below:
+
+```javascript
+const consumer = Cable.createConsumer('ws://0.0.0.0:3000/cable', { origin: 'http://0.0.0.0:3000' });
+```

--- a/dist/actioncable/Cable.js
+++ b/dist/actioncable/Cable.js
@@ -12,8 +12,8 @@ var _cableConsumer2 = _interopRequireDefault(_cableConsumer);
 
 exports["default"] = {
   PING_IDENTIFIER: "_ping",
-  createConsumer: function createConsumer(url) {
-    return new _cableConsumer2["default"](url);
+  createConsumer: function createConsumer(url, options) {
+    return new _cableConsumer2["default"](url, options);
   },
   // eac added 20150908
   endConsumer: function endConsumer(consumer) {

--- a/dist/actioncable/cable/Connection.js
+++ b/dist/actioncable/cable/Connection.js
@@ -13,11 +13,6 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 var slice = [].slice;
 var indexOf = [].indexOf;
 
-var isNode = typeof process !== 'undefined' && process.release.name === 'node';
-if (isNode) {
-  var WebSocket = require('websocket').w3cwebsocket;
-}
-
 var Connection = (function () {
   function Connection(consumer) {
     _classCallCheck(this, Connection);
@@ -63,7 +58,11 @@ var Connection = (function () {
       if (this.isState("open", "connecting")) {
         return;
       }
-      this.webSocket = new WebSocket(this.consumer.url, this.consumer.protocols, this.consumer.origin, this.consumer.headers, this.consumer.extraRequestOptions);
+      if (this.consumer.options.createWebsocket) {
+        this.webSocket = this.consumer.options.createWebsocket();
+      } else {
+        this.webSocket = new WebSocket(this.consumer.url);
+      }
       return this.installEventHandlers();
     }
   }, {

--- a/dist/actioncable/cable/Connection.js
+++ b/dist/actioncable/cable/Connection.js
@@ -1,17 +1,22 @@
 //# Encapsulate the cable connection held by the consumer. This is an internal class not intended for direct user manipulation.
 
-"use strict";
+'use strict';
 
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var slice = [].slice;
 var indexOf = [].indexOf;
+
+var isNode = typeof process !== 'undefined' && process.release.name === 'node';
+if (isNode) {
+  var WebSocket = require('websocket').w3cwebsocket;
+}
 
 var Connection = (function () {
   function Connection(consumer) {
@@ -21,8 +26,11 @@ var Connection = (function () {
     var _this = this;
     this.events = {
       message: function message(event) {
-        var identifier, message, ref;
-        ref = JSON.parse(event.data), identifier = ref.identifier, message = ref.message;
+        var identifier, message, ref, type;
+        ref = JSON.parse(event.data), identifier = ref.identifier, message = ref.message, type = ref.type;
+        if (['confirm_subscription', 'reject_subscription'].indexOf(type) >= 0) {
+          return;
+        }
         return _this.consumer.subscriptions.notify(identifier, "received", message);
       },
       open: function open() {
@@ -40,7 +48,7 @@ var Connection = (function () {
   }
 
   _createClass(Connection, [{
-    key: "send",
+    key: 'send',
     value: function send(data) {
       if (this.isOpen()) {
         this.webSocket.send(JSON.stringify(data));
@@ -50,16 +58,16 @@ var Connection = (function () {
       }
     }
   }, {
-    key: "open",
+    key: 'open',
     value: function open() {
       if (this.isState("open", "connecting")) {
         return;
       }
-      this.webSocket = new WebSocket(this.consumer.url);
+      this.webSocket = new WebSocket(this.consumer.url, this.consumer.protocols, this.consumer.origin, this.consumer.headers, this.consumer.extraRequestOptions);
       return this.installEventHandlers();
     }
   }, {
-    key: "close",
+    key: 'close',
     value: function close() {
       var ref;
       if (this.isState("closed", "closing")) {
@@ -68,7 +76,7 @@ var Connection = (function () {
       return (ref = this.webSocket) != null ? ref.close() : void 0;
     }
   }, {
-    key: "reopen",
+    key: 'reopen',
     value: function reopen() {
       if (this.isOpen()) {
         return this.closeSilently((function (_this) {
@@ -81,31 +89,28 @@ var Connection = (function () {
       }
     }
   }, {
-    key: "isOpen",
+    key: 'isOpen',
     value: function isOpen() {
       return this.isState("open");
     }
   }, {
-    key: "isState",
+    key: 'isState',
     value: function isState() {
       var ref, states;
       states = 1 <= arguments.length ? slice.call(arguments, 0) : [];
       return ref = this.getState(), indexOf.call(states, ref) >= 0;
     }
   }, {
-    key: "getState",
+    key: 'getState',
     value: function getState() {
       var ref, state, value;
-      for (state in WebSocket) {
-        value = WebSocket[state];
-        if (value === ((ref = this.webSocket) != null ? ref.readyState : void 0)) {
-          return state.toLowerCase();
-        }
+      var states = ['connecting', 'open', 'closing', 'closed'];
+      if (this.webSocket) {
+        return states[this.webSocket.readyState];
       }
-      return null;
     }
   }, {
-    key: "closeSilently",
+    key: 'closeSilently',
     value: function closeSilently(callback) {
       if (callback == null) {
         callback = function () {};
@@ -120,7 +125,7 @@ var Connection = (function () {
       }
     }
   }, {
-    key: "installEventHandlers",
+    key: 'installEventHandlers',
     value: function installEventHandlers() {
       var eventName, results;
       results = [];
@@ -130,7 +135,7 @@ var Connection = (function () {
       return results;
     }
   }, {
-    key: "installEventHandler",
+    key: 'installEventHandler',
     value: function installEventHandler(eventName, handler) {
       if (handler == null) {
         handler = this.events[eventName].bind(this);
@@ -138,7 +143,7 @@ var Connection = (function () {
       return this.webSocket.addEventListener(eventName, handler);
     }
   }, {
-    key: "uninstallEventHandlers",
+    key: 'uninstallEventHandlers',
     value: function uninstallEventHandlers() {
       var eventName, results;
       results = [];
@@ -148,7 +153,7 @@ var Connection = (function () {
       return results;
     }
   }, {
-    key: "toJSON",
+    key: 'toJSON',
     value: function toJSON() {
       return {
         state: this.getState()
@@ -159,5 +164,5 @@ var Connection = (function () {
   return Connection;
 })();
 
-exports["default"] = Connection;
-module.exports = exports["default"];
+exports['default'] = Connection;
+module.exports = exports['default'];

--- a/dist/actioncable/cable/Consumer.js
+++ b/dist/actioncable/cable/Consumer.js
@@ -41,10 +41,20 @@ var _ConnectionMonitor = require('./ConnectionMonitor');
 var _ConnectionMonitor2 = _interopRequireDefault(_ConnectionMonitor);
 
 var Consumer = (function () {
-  function Consumer(url) {
+  function Consumer(url, options) {
     _classCallCheck(this, Consumer);
 
     this.url = url;
+
+    if (!options) {
+      options = {};
+    }
+    this.url = url;
+    this.protocols = options.protocols;
+    this.origin = options.origin;
+    this.headers = options.headers;
+    this.extraRequestOptions = options.extraRequestOptions;
+
     this.subscriptions = new _Subscriptions2['default'](this);
     this.connection = new _Connection2['default'](this);
     this.connectionMonitor = new _ConnectionMonitor2['default'](this);

--- a/dist/actioncable/cable/Consumer.js
+++ b/dist/actioncable/cable/Consumer.js
@@ -45,15 +45,10 @@ var Consumer = (function () {
     _classCallCheck(this, Consumer);
 
     this.url = url;
-
     if (!options) {
       options = {};
     }
-    this.url = url;
-    this.protocols = options.protocols;
-    this.origin = options.origin;
-    this.headers = options.headers;
-    this.extraRequestOptions = options.extraRequestOptions;
+    this.options = options;
 
     this.subscriptions = new _Subscriptions2['default'](this);
     this.connection = new _Connection2['default'](this);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "url": "https://github.com/eacaps/es6-actioncable/issues"
   },
   "homepage": "https://github.com/eacaps/es6-actioncable",
+  "dependencies": {
+    "websocket": "^1.0.22"
+  },
   "devDependencies": {
     "babel": "^5.8.23"
   }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "url": "https://github.com/eacaps/es6-actioncable/issues"
   },
   "homepage": "https://github.com/eacaps/es6-actioncable",
-  "dependencies": {
-    "websocket": "^1.0.22"
-  },
   "devDependencies": {
     "babel": "^5.8.23"
   }

--- a/src/actioncable/Cable.js
+++ b/src/actioncable/Cable.js
@@ -2,8 +2,8 @@ import Consumer from './cable/Consumer';
 
 export default {
   PING_IDENTIFIER: "_ping",
-  createConsumer: (url) => {
-    return new Consumer(url);
+  createConsumer: (url, options) => {
+    return new Consumer(url, options);
   },
   // eac added 20150908
   endConsumer: (consumer) => {

--- a/src/actioncable/cable/Connection.js
+++ b/src/actioncable/cable/Connection.js
@@ -3,11 +3,6 @@
 var slice = [].slice;
 var indexOf = [].indexOf;
 
-const isNode = (typeof process !== 'undefined') && (process.release.name === 'node');
-if (isNode) {
-  var WebSocket = require('websocket').w3cwebsocket;
-}
-
 class Connection {
   constructor(consumer) {
     this.consumer = consumer;
@@ -46,13 +41,11 @@ class Connection {
     if (this.isState("open", "connecting")) {
       return;
     }
-    this.webSocket = new WebSocket(
-      this.consumer.url,
-      this.consumer.protocols,
-      this.consumer.origin,
-      this.consumer.headers,
-      this.consumer.extraRequestOptions
-    );
+    if(this.consumer.options.createWebsocket) {
+      this.webSocket = this.consumer.options.createWebsocket();
+    } else {
+      this.webSocket = new WebSocket(this.consumer.url);
+    }
     return this.installEventHandlers();
   }
 

--- a/src/actioncable/cable/Connection.js
+++ b/src/actioncable/cable/Connection.js
@@ -3,14 +3,20 @@
 var slice = [].slice;
 var indexOf = [].indexOf;
 
+const isNode = (typeof process !== 'undefined') && (process.release.name === 'node');
+if (isNode) {
+  var WebSocket = require('websocket').w3cwebsocket;
+}
+
 class Connection {
   constructor(consumer) {
     this.consumer = consumer;
     let _this = this;
     this.events = {
       message: function(event) {
-        var identifier, message, ref;
-        ref = JSON.parse(event.data), identifier = ref.identifier, message = ref.message;
+        var identifier, message, ref, type;
+        ref = JSON.parse(event.data), identifier = ref.identifier, message = ref.message, type = ref.type;
+        if (['confirm_subscription', 'reject_subscription'].indexOf(type) >= 0) { return; }
         return _this.consumer.subscriptions.notify(identifier, "received", message);
       },
       open: function() {
@@ -40,7 +46,13 @@ class Connection {
     if (this.isState("open", "connecting")) {
       return;
     }
-    this.webSocket = new WebSocket(this.consumer.url);
+    this.webSocket = new WebSocket(
+      this.consumer.url,
+      this.consumer.protocols,
+      this.consumer.origin,
+      this.consumer.headers,
+      this.consumer.extraRequestOptions
+    );
     return this.installEventHandlers();
   }
 
@@ -76,13 +88,10 @@ class Connection {
 
   getState() {
     var ref, state, value;
-    for (state in WebSocket) {
-      value = WebSocket[state];
-      if (value === ((ref = this.webSocket) != null ? ref.readyState : void 0)) {
-        return state.toLowerCase();
-      }
+    var states = ['connecting','open','closing','closed'];
+    if (this.webSocket) {
+      return states[this.webSocket.readyState];
     }
-    return null;
   }
 
   closeSilently(callback) {

--- a/src/actioncable/cable/Consumer.js
+++ b/src/actioncable/cable/Consumer.js
@@ -20,13 +20,8 @@ import ConnectionMonitor from './ConnectionMonitor';
 class Consumer {
   constructor(url, options) {
     this.url = url;
-
     if (!options) { options = {}; }
-    this.url = url;
-    this.protocols = options.protocols;
-    this.origin = options.origin;
-    this.headers = options.headers;
-    this.extraRequestOptions = options.extraRequestOptions;
+    this.options = options;
 
     this.subscriptions = new Subscriptions(this);
     this.connection = new Connection(this);

--- a/src/actioncable/cable/Consumer.js
+++ b/src/actioncable/cable/Consumer.js
@@ -18,8 +18,16 @@ import Connection from './Connection';
 import ConnectionMonitor from './ConnectionMonitor';
 
 class Consumer {
-  constructor(url) {
+  constructor(url, options) {
     this.url = url;
+
+    if (!options) { options = {}; }
+    this.url = url;
+    this.protocols = options.protocols;
+    this.origin = options.origin;
+    this.headers = options.headers;
+    this.extraRequestOptions = options.extraRequestOptions;
+
     this.subscriptions = new Subscriptions(this);
     this.connection = new Connection(this);
     this.connectionMonitor = new ConnectionMonitor(this);


### PR DESCRIPTION
This project was initially created to only support action cable connections via the browser so it assumes that the WebSocket library would be provided by the browser. These changes allow users to specify a function to create the websocket in the options(createWebsocket). This allows action cable to be used in node.js via the https://www.npmjs.com/package/websocket package. An example is provided in the README. Thanks to @mattheworiordan for providing this use case.
