### PR TITLE
Support passing in headers to Action Cable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ MyChannel.js
 
 Actioncable is good stuff, even if it is in Ruby.
 
+## Adding your own headers.
+
+If you need to put data in the header, you can use `options.headers`
+
+    let headers = { Cookie: 'key=value' };
+
+    Cable.createConsumer(url, { headers } );
+
 ## Connecting from Node.js
 
 `es6-actioncable` will work under Node.js, however you will need to bear the following in mind:

--- a/dist/actioncable/cable/Connection.js
+++ b/dist/actioncable/cable/Connection.js
@@ -61,7 +61,7 @@ var Connection = (function () {
       if (this.consumer.options.createWebsocket) {
         this.webSocket = this.consumer.options.createWebsocket();
       } else {
-        this.webSocket = new WebSocket(this.consumer.url);
+        this.webSocket = new WebSocket(this.consumer.url, '', this.consumer.options.headers);
       }
       return this.installEventHandlers();
     }

--- a/dist/actioncable/cable/Subscriptions.js
+++ b/dist/actioncable/cable/Subscriptions.js
@@ -134,7 +134,9 @@ var Subscriptions = (function () {
       results = [];
       for (i = 0, len = subscriptions.length; i < len; i++) {
         subscription = subscriptions[i];
-        results.push(typeof subscription[callbackName] === "function" ? subscription[callbackName].apply(subscription, args) : void 0);
+        if (subscription) {
+          results.push(typeof subscription[callbackName] === "function" ? subscription[callbackName].apply(subscription, args) : void 0);
+        }
       }
       return results;
     }

--- a/src/actioncable/cable/Connection.js
+++ b/src/actioncable/cable/Connection.js
@@ -44,7 +44,7 @@ class Connection {
     if(this.consumer.options.createWebsocket) {
       this.webSocket = this.consumer.options.createWebsocket();
     } else {
-      this.webSocket = new WebSocket(this.consumer.url);
+      this.webSocket = new WebSocket(this.consumer.url, '', this.consumer.options.headers);
     }
     return this.installEventHandlers();
   }

--- a/src/actioncable/cable/Subscriptions.js
+++ b/src/actioncable/cable/Subscriptions.js
@@ -107,7 +107,9 @@ class Subscriptions {
     results = [];
     for (i = 0, len = subscriptions.length; i < len; i++) {
       subscription = subscriptions[i];
-      results.push(typeof subscription[callbackName] === "function" ? subscription[callbackName].apply(subscription, args) : void 0);
+      if(subscription) {
+        results.push(typeof subscription[callbackName] === "function" ? subscription[callbackName].apply(subscription, args) : void 0);
+      }
     }
     return results;
   }


### PR DESCRIPTION
Support an optional `headers` key on `options`. 

(I currently need this for authentication from a native iOS app.)
